### PR TITLE
Add query name comments

### DIFF
--- a/lib/pg_jbuilder.rb
+++ b/lib/pg_jbuilder.rb
@@ -25,7 +25,7 @@ module PgJbuilder
         _erbout << ")object_row)"
       else
         "(SELECT COALESCE(row_to_json(object_row),'{}'::json) FROM (\n" +
-          include(query, variables, include_query_name_comment: false) +
+          include(query, variables) +
           "\n)object_row)"
       end
     end
@@ -38,7 +38,7 @@ module PgJbuilder
         _erbout << ")array_row)"
       else
         "(SELECT COALESCE(array_to_json(array_agg(row_to_json(array_row))),'[]'::json) FROM (\n" +
-          include(query, variables, include_query_name_comment: false) +
+          include(query, variables) +
           "\n)array_row)"
       end
     end
@@ -52,7 +52,7 @@ module PgJbuilder
 
     def include(query, variables={}, options={})
       dsl = new_sub_dsl(variables)
-      PgJbuilder.render(query, variables, dsl: dsl, query_name: false)
+      PgJbuilder.render(query, variables, dsl: dsl, include_query_name_comment: false)
     end
 
     def get_binding

--- a/lib/pg_jbuilder.rb
+++ b/lib/pg_jbuilder.rb
@@ -83,7 +83,7 @@ module PgJbuilder
     dsl = options[:dsl] || BuilderDSL.new(variables)
     output = []
     if options[:include_query_name_comment] != false
-      output << ["-- query: #{query}"]
+      output << ["\n-- query: #{query}\n"]
     end
     output << compiled.result(dsl.get_binding)
     output.join("\n")

--- a/lib/pg_jbuilder/railtie.rb
+++ b/lib/pg_jbuilder/railtie.rb
@@ -20,22 +20,21 @@ module PgJbuilder
     extend ActiveSupport::Concern
     
     def render_json_array(template, variables={})
-      sql = PgJbuilder.render_array(template, variables, include_query_name_comment: false)
-      render json: PgJbuilder.connection.select_value(sql)
+      sql = ["-- query: #{template}"]
+      sql << PgJbuilder.render_array(template, variables, include_query_name_comment: false)
+      render json: PgJbuilder.connection.select_value(sql.join("\n"))
     end
     
     def render_json_object(template, variables={})
-      sql = PgJbuilder.render_object(template, variables, include_query_name_comment: false)
-      output = ["-- query: #{template}"]
-      output << PgJbuilder.connection.select_value(sql)
-      render json: output.join("\n")
+      sql = ["-- query: #{template}"]
+      sql << PgJbuilder.render_object(template, variables, include_query_name_comment: false)
+      render json: PgJbuilder.connection.select_value(sql.join("\n"))
     end
     
     def render_value(template, variables={})
-      sql = PgJbuilder.render(template, variables, include_query_name_comment: false)
-      output = ["-- query: #{template}"]
-      output << PgJbuilder.connection.select_value(sql)
-      output.join("\n")
+      sql = ["-- query: #{template}"]
+      sql << PgJbuilder.render(template, variables, include_query_name_comment: false)
+      PgJbuilder.connection.select_value(sql.join("\n"))
     end
   end
 

--- a/lib/pg_jbuilder/railtie.rb
+++ b/lib/pg_jbuilder/railtie.rb
@@ -20,18 +20,22 @@ module PgJbuilder
     extend ActiveSupport::Concern
     
     def render_json_array(template, variables={})
-      sql = PgJbuilder.render_array(template, variables)
+      sql = PgJbuilder.render_array(template, variables, include_query_name_comment: false)
       render json: PgJbuilder.connection.select_value(sql)
     end
     
     def render_json_object(template, variables={})
-      sql = PgJbuilder.render_object(template, variables)
-      render json: PgJbuilder.connection.select_value(sql)
+      sql = PgJbuilder.render_object(template, variables, include_query_name_comment: false)
+      output = ["-- query: #{template}"]
+      output << PgJbuilder.connection.select_value(sql)
+      render json: output.join("\n")
     end
     
     def render_value(template, variables={})
-      sql = PgJbuilder.render(template, variables)
-      PgJbuilder.connection.select_value(sql)
+      sql = PgJbuilder.render(template, variables, include_query_name_comment: false)
+      output = ["-- query: #{template}"]
+      output << PgJbuilder.connection.select_value(sql)
+      output.join("\n")
     end
   end
 


### PR DESCRIPTION
Adds a comment to the top of each query when rendered with the name of the query.

These will hopefully show up in AWS performance insights, helpfully labelling each query with a location in the code.